### PR TITLE
Fix REQUIRE_BINARY error detection

### DIFF
--- a/GettextTranslate.cmake
+++ b/GettextTranslate.cmake
@@ -79,8 +79,8 @@ add_custom_target(update-gmo ${_addToALL})
 #xgettext, msginit, msgfilter, msgconv, msgmerge, msgfmt
 
 function(REQUIRE_BINARY binname varname)
-  if (defined ${${varname}-NOTFOUND})
-    message(FATAL_ERROR "Could not find " binname)
+  if (${${varname}} STREQUAL "${varname}-NOTFOUND")
+    message(FATAL_ERROR "Could not find " ${binname})
   endif()
 endfunction()
 


### PR DESCRIPTION
`REQUIRE_BINARY` will be invoked with the result of a [find_program](https://cmake.org/cmake/help/v3.7/command/find_program.html) invocation. The old `REQUIRE_BINARY` implementation assumed, an unfound program would result in the definition of a second variable `VAR-NOTFOUND`. Instead the actual behaviour of `find_program` will assign the value `VAR-NOTFOUND` to the variable `VAR`. Thus the new implementation will catch errors finding programs while the old did not.

Moreover the error message is fixed, old output was `Could not find binname` while the new will substitue the variable `binname` thus resulting in e.g. `Could not find xgettext`.

This patch is relevant to (at least) [violetland](https://github.com/ooxi/violetland/pull/137), which uses your project as submodule and would like continuing to do so :+1: 